### PR TITLE
BUGFIX: Remove changes to styling on "destroy"

### DIFF
--- a/src/js/coverflow.js
+++ b/src/js/coverflow.js
@@ -504,8 +504,8 @@
 		},
 		_ui : function ( active, index ) {
 			return {
-				active: this.activeItem,
-				index: index || this.currentIndex
+				active: active || this.activeItem,
+				index: typeof index === "undefined" ? this.currentIndex : index
 			};
 		},
 		_onMouseWheel : function ( ev ) {


### PR DESCRIPTION
Previously, the code left "residue" on the affected elements after "destroy" in the form of extra classes and styles that weren't there before the plugin was initialized. This checkin helps remove some of the effect.
