### PR TITLE
Fixed Typo: $.msie.version to $.browser.version

### DIFF
--- a/dist/coverflow.js
+++ b/dist/coverflow.js
@@ -139,7 +139,7 @@
 
 		if( $.browser != null ) {
 			// old jQuery versions and jQuery migrate plugin users
-			return $.browser.msie && ( ( ~~$.msie.version ) < 10 );
+			return $.browser.msie && ( ( ~~$.browser.version ) < 10 );
 		}
 
 		var match = /(msie) ([\w.]+)/.exec( navigator.userAgent.toLowerCase() );


### PR DESCRIPTION
Fixed Typo that was causing error in IE: 'msie.version is null or not an object'
